### PR TITLE
Transform app into Minecraft pixel map generator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,7 @@
   --ui-void-color: #d0d4de;
   --github-mark: url('/github-mark.svg');
   --ui-border-radius: 8px;
+  --accent-color: #10b981;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -28,6 +29,7 @@
     --ui-border-color: #606060;
     --ui-void-color: #4e4e4e;
     --github-mark: url('/github-mark-white.svg');
+    --accent-color: #059669;
   }
 }
 
@@ -232,5 +234,79 @@ button {
     margin: 0;
     border-width: 1px 0 1px 0;
     border-radius: 0;
+  }
+}
+
+/* Pixel Map Generator Styles */
+
+.app-title {
+  margin: 0 0 4px 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.app-subtitle {
+  margin: 0 0 12px 0;
+  font-size: 12px;
+  opacity: 0.6;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--ui-border-color);
+}
+
+.section-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.shape-tools-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  background-color: var(--ui-void-color);
+  border-radius: var(--ui-border-radius);
+}
+
+#current-tool-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 4px;
+  padding: 4px 12px;
+  background-color: var(--ui-background-color);
+  border: 1px solid var(--ui-border-color);
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+/* Drawn pixels styling */
+.drawn-pixel {
+  stroke: none;
+}
+
+.preview-pixel {
+  stroke: none;
+  pointer-events: none;
+}
+
+/* Settings container adjustments for more content */
+#settings-container {
+  min-width: 280px;
+  max-width: 320px;
+}
+
+@media (orientation: portrait) {
+  #settings-container {
+    max-width: none;
+    min-width: auto;
   }
 }

--- a/src/components/ColorPalette.css
+++ b/src/components/ColorPalette.css
@@ -1,0 +1,110 @@
+.color-palette {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.palette-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.palette-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+}
+
+.current-color-preview {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--ui-border-color);
+  border-radius: 4px;
+}
+
+.current-color-info {
+  padding: 6px 8px;
+  background-color: var(--ui-void-color);
+  border-radius: 4px;
+  text-align: center;
+}
+
+.current-color-name {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.color-categories {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.color-category {
+  display: flex;
+  flex-direction: column;
+}
+
+.category-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  background-color: transparent;
+  color: var(--text-color);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.category-header:hover {
+  background-color: var(--ui-void-color);
+}
+
+.category-header.expanded {
+  background-color: var(--ui-void-color);
+}
+
+.category-name {
+  font-weight: 500;
+}
+
+.category-arrow {
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+.category-colors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px;
+  padding-top: 4px;
+}
+
+.color-swatch {
+  width: 28px;
+  height: 28px;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.color-swatch:hover {
+  transform: scale(1.1);
+  border-color: var(--text-color);
+}
+
+.color-swatch.selected {
+  border-color: var(--text-color);
+  box-shadow: 0 0 0 2px var(--ui-background-color), 0 0 0 4px var(--cell-color);
+}

--- a/src/components/ColorPalette.tsx
+++ b/src/components/ColorPalette.tsx
@@ -1,0 +1,68 @@
+import { JSX, For, createSignal } from 'solid-js';
+import { minecraftColors, colorCategories, BlockColor } from '../data/minecraftColors';
+import { currentColor, setCurrentColor } from '../stores/drawingState';
+import './ColorPalette.css';
+
+const ColorPalette = (): JSX.Element => {
+  const [expandedCategory, setExpandedCategory] = createSignal<string | null>('stone');
+
+  const toggleCategory = (categoryId: string): void => {
+    setExpandedCategory(expandedCategory() === categoryId ? null : categoryId);
+  };
+
+  const getColorsByCategory = (categoryId: string): BlockColor[] =>
+    minecraftColors.filter((c) => c.category === categoryId);
+
+  return (
+    <div class="color-palette">
+      <div class="palette-header">
+        <span class="palette-label">Block Colors</span>
+        <div
+          class="current-color-preview"
+          style={{ 'background-color': currentColor().color }}
+          title={currentColor().name}
+        />
+      </div>
+
+      <div class="current-color-info">
+        <span class="current-color-name">{currentColor().name}</span>
+      </div>
+
+      <div class="color-categories">
+        <For each={colorCategories}>
+          {(category) => (
+            <div class="color-category">
+              <button
+                class="category-header"
+                classList={{ expanded: expandedCategory() === category.id }}
+                onClick={() => toggleCategory(category.id)}
+              >
+                <span class="category-name">{category.name}</span>
+                <span class="category-arrow">{expandedCategory() === category.id ? '▼' : '▶'}</span>
+              </button>
+
+              {expandedCategory() === category.id && (
+                <div class="category-colors">
+                  <For each={getColorsByCategory(category.id)}>
+                    {(color) => (
+                      <button
+                        class="color-swatch"
+                        classList={{ selected: currentColor().id === color.id }}
+                        style={{ 'background-color': color.color }}
+                        onClick={() => setCurrentColor(color)}
+                        title={color.name}
+                        aria-label={color.name}
+                      />
+                    )}
+                  </For>
+                </div>
+              )}
+            </div>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+};
+
+export default ColorPalette;

--- a/src/components/LayerPanel.css
+++ b/src/components/LayerPanel.css
@@ -1,0 +1,129 @@
+.layer-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.layer-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+}
+
+.layer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.layer-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.layer-item.active {
+  background-color: var(--ui-void-color);
+}
+
+.layer-visibility {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background-color: transparent;
+  font-size: 14px;
+  cursor: pointer;
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
+.layer-visibility.hidden {
+  opacity: 0.4;
+}
+
+.layer-visibility:hover {
+  background-color: var(--ui-void-color);
+}
+
+.layer-select {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: 1;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  background-color: transparent;
+  color: var(--text-color);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.layer-select:hover {
+  background-color: var(--ui-void-color);
+}
+
+.layer-item.active .layer-select {
+  background-color: var(--cell-color);
+  color: #fff;
+}
+
+.layer-name {
+  font-weight: 500;
+}
+
+.layer-count {
+  font-size: 11px;
+  opacity: 0.7;
+  padding: 2px 6px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+}
+
+.layer-item.active .layer-count {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.layer-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background-color: transparent;
+  font-size: 12px;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: all 0.15s ease;
+}
+
+.layer-clear:hover {
+  background-color: var(--cell-highlight-color);
+  opacity: 1;
+}
+
+.layer-info {
+  padding: 6px 8px;
+  background-color: var(--ui-void-color);
+  border-radius: 4px;
+  text-align: center;
+}
+
+.layer-info small {
+  font-size: 11px;
+  opacity: 0.8;
+}

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -1,0 +1,69 @@
+import { JSX, For } from 'solid-js';
+import {
+  Layer,
+  layers,
+  activeLayer,
+  setActiveLayer,
+  layerVisibility,
+  toggleLayerVisibility,
+} from '../stores/drawingState';
+import { clearLayer, getPixelsByLayer } from '../stores/pixelStore';
+import './LayerPanel.css';
+
+const LayerPanel = (): JSX.Element => {
+  const getLayerPixelCount = (layerId: Layer): number => {
+    return getPixelsByLayer(layerId).length;
+  };
+
+  return (
+    <div class="layer-panel">
+      <span class="layer-label">Layers</span>
+
+      <div class="layer-list">
+        <For each={layers}>
+          {(layer) => (
+            <div
+              class="layer-item"
+              classList={{ active: activeLayer() === layer.id }}
+            >
+              <button
+                class="layer-visibility"
+                classList={{ hidden: !layerVisibility()[layer.id] }}
+                onClick={() => toggleLayerVisibility(layer.id)}
+                title={layerVisibility()[layer.id] ? 'Hide layer' : 'Show layer'}
+              >
+                {layerVisibility()[layer.id] ? '👁️' : '👁️‍🗨️'}
+              </button>
+
+              <button
+                class="layer-select"
+                onClick={() => setActiveLayer(layer.id)}
+              >
+                <span class="layer-name">{layer.name}</span>
+                <span class="layer-count">{getLayerPixelCount(layer.id)}</span>
+              </button>
+
+              <button
+                class="layer-clear"
+                onClick={() => {
+                  if (confirm(`Clear all pixels in "${layer.name}" layer?`)) {
+                    clearLayer(layer.id);
+                  }
+                }}
+                title="Clear layer"
+              >
+                🗑️
+              </button>
+            </div>
+          )}
+        </For>
+      </div>
+
+      <div class="layer-info">
+        <small>Drawing to: <strong>{layers.find(l => l.id === activeLayer())?.name}</strong></small>
+      </div>
+    </div>
+  );
+};
+
+export default LayerPanel;

--- a/src/components/Legend.css
+++ b/src/components/Legend.css
@@ -1,0 +1,72 @@
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.legend-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+}
+
+.legend-empty {
+  font-size: 12px;
+  opacity: 0.5;
+  text-align: center;
+  padding: 12px;
+  margin: 0;
+}
+
+.legend-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  background-color: transparent;
+  color: var(--text-color);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  text-align: left;
+}
+
+.legend-item:hover {
+  background-color: var(--ui-void-color);
+}
+
+.legend-color {
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--ui-border-color);
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.legend-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.legend-count {
+  font-size: 10px;
+  opacity: 0.6;
+  padding: 2px 6px;
+  background-color: var(--ui-void-color);
+  border-radius: 10px;
+}

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,0 +1,48 @@
+import { JSX, For, Show } from 'solid-js';
+import { getUsedColors } from '../stores/pixelStore';
+import { setCurrentColor } from '../stores/drawingState';
+import { getColorById } from '../data/minecraftColors';
+import './Legend.css';
+
+const Legend = (): JSX.Element => {
+  const usedColors = getUsedColors;
+
+  const handleColorClick = (blockId: string): void => {
+    const color = getColorById(blockId);
+    if (color) {
+      setCurrentColor(color);
+    }
+  };
+
+  return (
+    <div class="legend">
+      <span class="legend-label">Legend</span>
+
+      <Show
+        when={usedColors().length > 0}
+        fallback={<p class="legend-empty">No blocks placed yet</p>}
+      >
+        <div class="legend-items">
+          <For each={usedColors()}>
+            {(item) => (
+              <button
+                class="legend-item"
+                onClick={() => handleColorClick(item.blockId)}
+                title={`Click to select ${item.blockName}`}
+              >
+                <div
+                  class="legend-color"
+                  style={{ 'background-color': item.color }}
+                />
+                <span class="legend-name">{item.blockName}</span>
+                <span class="legend-count">{item.count}</span>
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default Legend;

--- a/src/components/PixelCanvas.tsx
+++ b/src/components/PixelCanvas.tsx
@@ -1,0 +1,66 @@
+import { JSX, For, createMemo } from 'solid-js';
+import { pixels, Pixel } from '../stores/pixelStore';
+import { layerVisibility, drawPreview, currentColor } from '../stores/drawingState';
+
+// Component to render a single drawn pixel
+const DrawnPixel = (props: { pixel: Pixel }): JSX.Element => {
+  return (
+    <rect
+      x={props.pixel.x}
+      y={-props.pixel.y - 1}
+      width="1"
+      height="1"
+      fill={props.pixel.color}
+      class="drawn-pixel"
+      data-block-id={props.pixel.blockId}
+      data-layer={props.pixel.layer}
+    />
+  );
+};
+
+// Component to render preview pixels (for line/rectangle tools)
+const PreviewPixel = (props: { x: number; y: number; color: string }): JSX.Element => {
+  return (
+    <rect
+      x={props.x}
+      y={-props.y - 1}
+      width="1"
+      height="1"
+      fill={props.color}
+      class="preview-pixel"
+      opacity="0.6"
+    />
+  );
+};
+
+// Main component to render all drawn pixels
+const PixelCanvas = (): JSX.Element => {
+  // Filter pixels based on layer visibility
+  const visiblePixels = createMemo(() => {
+    const visibility = layerVisibility();
+    return Array.from(pixels().values()).filter(
+      (pixel) => visibility[pixel.layer]
+    );
+  });
+
+  const previewPixels = drawPreview;
+  const previewColor = () => currentColor().color;
+
+  return (
+    <g class="pixel-canvas">
+      {/* Render all visible drawn pixels */}
+      <For each={visiblePixels()}>
+        {(pixel) => <DrawnPixel pixel={pixel} />}
+      </For>
+
+      {/* Render preview pixels for line/rectangle tools */}
+      <For each={previewPixels()}>
+        {(pos) => (
+          <PreviewPixel x={pos.x} y={pos.y} color={previewColor()} />
+        )}
+      </For>
+    </g>
+  );
+};
+
+export default PixelCanvas;

--- a/src/components/ProjectActions.css
+++ b/src/components/ProjectActions.css
@@ -1,0 +1,54 @@
+.project-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.actions-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+}
+
+.actions-buttons {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.action-btn {
+  flex: 1;
+  min-width: 70px;
+  padding: 8px 10px;
+  border: 1px solid var(--ui-border-color);
+  border-radius: 6px;
+  background-color: var(--ui-background-color);
+  color: var(--text-color);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.action-btn:hover {
+  background-color: var(--ui-void-color);
+}
+
+.action-btn.save:hover {
+  background-color: #4ade80;
+  border-color: #4ade80;
+  color: #fff;
+}
+
+.action-btn.load:hover {
+  background-color: #60a5fa;
+  border-color: #60a5fa;
+  color: #fff;
+}
+
+.action-btn.clear:hover {
+  background-color: #f87171;
+  border-color: #f87171;
+  color: #fff;
+}

--- a/src/components/ProjectActions.tsx
+++ b/src/components/ProjectActions.tsx
@@ -1,0 +1,68 @@
+import { JSX } from 'solid-js';
+import { exportProject, importProject, clearAllPixels, getAllPixels } from '../stores/pixelStore';
+import './ProjectActions.css';
+
+const ProjectActions = (): JSX.Element => {
+  const handleSave = (): void => {
+    const data = exportProject();
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `pixel-map-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleLoad = (): void => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const content = event.target?.result as string;
+        if (importProject(content)) {
+          alert('Project loaded successfully!');
+        } else {
+          alert('Failed to load project. Invalid file format.');
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  };
+
+  const handleClear = (): void => {
+    const pixelCount = getAllPixels().length;
+    if (pixelCount === 0) {
+      alert('Canvas is already empty!');
+      return;
+    }
+    if (confirm(`Are you sure you want to clear all ${pixelCount} pixels? This cannot be undone.`)) {
+      clearAllPixels();
+    }
+  };
+
+  return (
+    <div class="project-actions">
+      <span class="actions-label">Project</span>
+      <div class="actions-buttons">
+        <button class="action-btn save" onClick={handleSave} title="Save project">
+          💾 Save
+        </button>
+        <button class="action-btn load" onClick={handleLoad} title="Load project">
+          📂 Load
+        </button>
+        <button class="action-btn clear" onClick={handleClear} title="Clear all pixels">
+          🗑️ Clear
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectActions;

--- a/src/components/Toolbar.css
+++ b/src/components/Toolbar.css
@@ -1,0 +1,84 @@
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--ui-border-color);
+}
+
+.toolbar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.toolbar-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+}
+
+.tool-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tool-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 52px;
+  padding: 4px;
+  border: 1px solid var(--ui-border-color);
+  border-radius: 6px;
+  background-color: var(--ui-background-color);
+  color: var(--text-color);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tool-button:hover {
+  background-color: var(--ui-void-color);
+}
+
+.tool-button.active {
+  background-color: var(--cell-color);
+  border-color: var(--cell-color);
+  color: #fff;
+}
+
+.tool-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.tool-name {
+  font-size: 10px;
+  margin-top: 2px;
+}
+
+.shape-tools-toggle {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--ui-border-color);
+  border-radius: 6px;
+  background-color: var(--ui-background-color);
+  color: var(--text-color);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.shape-tools-toggle:hover {
+  background-color: var(--ui-void-color);
+}
+
+.shape-tools-toggle.active {
+  background-color: var(--cell-debug-color);
+  border-color: var(--cell-debug-color);
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,0 +1,56 @@
+import { JSX, For } from 'solid-js';
+import { Tool, currentTool, setCurrentTool, showShapeTools, setShowShapeTools } from '../stores/drawingState';
+import './Toolbar.css';
+
+interface ToolConfig {
+  id: Tool;
+  name: string;
+  icon: string;
+  description: string;
+}
+
+const tools: ToolConfig[] = [
+  { id: 'select', name: 'Pan', icon: '✋', description: 'Pan and zoom the canvas' },
+  { id: 'pencil', name: 'Pencil', icon: '✏️', description: 'Draw single pixels' },
+  { id: 'eraser', name: 'Eraser', icon: '🧹', description: 'Remove pixels' },
+  { id: 'line', name: 'Line', icon: '📏', description: 'Draw straight lines (paths)' },
+  { id: 'rectangle', name: 'Rectangle', icon: '⬜', description: 'Fill rectangular areas' },
+  { id: 'fill', name: 'Fill', icon: '🪣', description: 'Flood fill area' },
+];
+
+const Toolbar = (): JSX.Element => {
+  return (
+    <div class="toolbar">
+      <div class="toolbar-section">
+        <span class="toolbar-label">Tools</span>
+        <div class="tool-buttons">
+          <For each={tools}>
+            {(tool) => (
+              <button
+                class="tool-button"
+                classList={{ active: currentTool() === tool.id }}
+                onClick={() => setCurrentTool(tool.id)}
+                title={tool.description}
+                aria-label={tool.name}
+              >
+                <span class="tool-icon">{tool.icon}</span>
+                <span class="tool-name">{tool.name}</span>
+              </button>
+            )}
+          </For>
+        </div>
+      </div>
+      <div class="toolbar-section">
+        <button
+          class="shape-tools-toggle"
+          classList={{ active: showShapeTools() }}
+          onClick={() => setShowShapeTools(!showShapeTools())}
+        >
+          {showShapeTools() ? 'Hide Shapes' : 'Shape Generator'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Toolbar;

--- a/src/data/minecraftColors.ts
+++ b/src/data/minecraftColors.ts
@@ -1,0 +1,90 @@
+// Minecraft block colors for pixel map planning
+// Colors are approximate representations of common building blocks
+
+export interface BlockColor {
+  id: string;
+  name: string;
+  color: string;
+  category: 'terrain' | 'wood' | 'stone' | 'decoration' | 'utility' | 'path' | 'water' | 'vegetation';
+}
+
+export const minecraftColors: BlockColor[] = [
+  // Terrain
+  { id: 'grass', name: 'Grass', color: '#5D8C3E', category: 'terrain' },
+  { id: 'dirt', name: 'Dirt', color: '#8B5A2B', category: 'terrain' },
+  { id: 'sand', name: 'Sand', color: '#E5D9A8', category: 'terrain' },
+  { id: 'gravel', name: 'Gravel', color: '#7F7F7F', category: 'terrain' },
+  { id: 'clay', name: 'Clay', color: '#9FA4B0', category: 'terrain' },
+
+  // Stone types
+  { id: 'stone', name: 'Stone', color: '#6D6D6D', category: 'stone' },
+  { id: 'cobblestone', name: 'Cobblestone', color: '#5A5A5A', category: 'stone' },
+  { id: 'stone_brick', name: 'Stone Brick', color: '#7A7A7A', category: 'stone' },
+  { id: 'deepslate', name: 'Deepslate', color: '#4A4A4A', category: 'stone' },
+  { id: 'andesite', name: 'Andesite', color: '#8A8A8A', category: 'stone' },
+  { id: 'granite', name: 'Granite', color: '#9A6A5A', category: 'stone' },
+  { id: 'diorite', name: 'Diorite', color: '#BFBFBF', category: 'stone' },
+  { id: 'blackstone', name: 'Blackstone', color: '#2D2D36', category: 'stone' },
+
+  // Wood types
+  { id: 'oak_planks', name: 'Oak Planks', color: '#B8945F', category: 'wood' },
+  { id: 'spruce_planks', name: 'Spruce Planks', color: '#6B5034', category: 'wood' },
+  { id: 'birch_planks', name: 'Birch Planks', color: '#D5C98C', category: 'wood' },
+  { id: 'dark_oak_planks', name: 'Dark Oak Planks', color: '#3E2912', category: 'wood' },
+  { id: 'acacia_planks', name: 'Acacia Planks', color: '#C06A3B', category: 'wood' },
+  { id: 'jungle_planks', name: 'Jungle Planks', color: '#AB8556', category: 'wood' },
+  { id: 'oak_log', name: 'Oak Log', color: '#6B5034', category: 'wood' },
+
+  // Paths and roads
+  { id: 'path', name: 'Path', color: '#C9A86C', category: 'path' },
+  { id: 'gravel_path', name: 'Gravel Path', color: '#9E9E9E', category: 'path' },
+  { id: 'cobblestone_path', name: 'Cobble Path', color: '#696969', category: 'path' },
+  { id: 'stone_path', name: 'Stone Path', color: '#808080', category: 'path' },
+
+  // Water and liquids
+  { id: 'water', name: 'Water', color: '#3F76E4', category: 'water' },
+  { id: 'water_deep', name: 'Deep Water', color: '#2356C4', category: 'water' },
+  { id: 'lava', name: 'Lava', color: '#CF5A00', category: 'water' },
+
+  // Vegetation
+  { id: 'leaves', name: 'Leaves', color: '#4A7A32', category: 'vegetation' },
+  { id: 'flower_red', name: 'Red Flower', color: '#D44', category: 'vegetation' },
+  { id: 'flower_yellow', name: 'Yellow Flower', color: '#ED2', category: 'vegetation' },
+  { id: 'crops', name: 'Crops/Farm', color: '#A2C052', category: 'vegetation' },
+
+  // Decoration blocks
+  { id: 'wool_white', name: 'White Wool', color: '#E9E9E9', category: 'decoration' },
+  { id: 'wool_red', name: 'Red Wool', color: '#A12722', category: 'decoration' },
+  { id: 'wool_blue', name: 'Blue Wool', color: '#2E388D', category: 'decoration' },
+  { id: 'wool_green', name: 'Green Wool', color: '#546D1B', category: 'decoration' },
+  { id: 'wool_yellow', name: 'Yellow Wool', color: '#F9C627', category: 'decoration' },
+  { id: 'wool_black', name: 'Black Wool', color: '#1D1D21', category: 'decoration' },
+  { id: 'terracotta', name: 'Terracotta', color: '#985F45', category: 'decoration' },
+  { id: 'brick', name: 'Brick', color: '#96614A', category: 'decoration' },
+
+  // Utility/markers
+  { id: 'marker_red', name: 'Marker (Red)', color: '#FF0000', category: 'utility' },
+  { id: 'marker_blue', name: 'Marker (Blue)', color: '#0066FF', category: 'utility' },
+  { id: 'marker_green', name: 'Marker (Green)', color: '#00CC00', category: 'utility' },
+  { id: 'marker_yellow', name: 'Marker (Yellow)', color: '#FFFF00', category: 'utility' },
+  { id: 'door', name: 'Door/Entrance', color: '#8B4513', category: 'utility' },
+  { id: 'fence', name: 'Fence', color: '#C49A6C', category: 'utility' },
+  { id: 'torch', name: 'Torch/Light', color: '#FFCC00', category: 'utility' },
+];
+
+export const colorCategories = [
+  { id: 'terrain', name: 'Terrain' },
+  { id: 'stone', name: 'Stone' },
+  { id: 'wood', name: 'Wood' },
+  { id: 'path', name: 'Paths' },
+  { id: 'water', name: 'Water' },
+  { id: 'vegetation', name: 'Plants' },
+  { id: 'decoration', name: 'Decoration' },
+  { id: 'utility', name: 'Markers' },
+] as const;
+
+export const getColorById = (id: string): BlockColor | undefined =>
+  minecraftColors.find(c => c.id === id);
+
+export const getColorsByCategory = (category: string): BlockColor[] =>
+  minecraftColors.filter(c => c.category === category);

--- a/src/stores/drawingState.ts
+++ b/src/stores/drawingState.ts
@@ -1,0 +1,70 @@
+import { createSignal } from 'solid-js';
+import { minecraftColors, BlockColor } from '../data/minecraftColors';
+
+export type Tool = 'select' | 'pencil' | 'eraser' | 'line' | 'rectangle' | 'fill';
+
+export type Layer = 'terrain' | 'structures' | 'paths' | 'markers';
+
+export const layers: { id: Layer; name: string; visible: boolean }[] = [
+  { id: 'terrain', name: 'Terrain', visible: true },
+  { id: 'structures', name: 'Structures', visible: true },
+  { id: 'paths', name: 'Paths/Roads', visible: true },
+  { id: 'markers', name: 'Markers', visible: true },
+];
+
+// Current tool selection
+const [currentTool, setCurrentTool] = createSignal<Tool>('pencil');
+
+// Current selected color
+const [currentColor, setCurrentColor] = createSignal<BlockColor>(minecraftColors[0]);
+
+// Current active layer
+const [activeLayer, setActiveLayer] = createSignal<Layer>('structures');
+
+// Layer visibility states
+const [layerVisibility, setLayerVisibility] = createSignal<Record<Layer, boolean>>({
+  terrain: true,
+  structures: true,
+  paths: true,
+  markers: true,
+});
+
+// Drawing state (for line/rectangle tools)
+const [isDrawing, setIsDrawing] = createSignal(false);
+const [drawStart, setDrawStart] = createSignal<{ x: number; y: number } | null>(null);
+const [drawPreview, setDrawPreview] = createSignal<{ x: number; y: number }[]>([]);
+
+// Shape tool integration mode
+const [showShapeTools, setShowShapeTools] = createSignal(false);
+
+// Toggle a specific layer's visibility
+const toggleLayerVisibility = (layer: Layer): void => {
+  setLayerVisibility({
+    ...layerVisibility(),
+    [layer]: !layerVisibility()[layer],
+  });
+};
+
+// Check if a layer is visible
+const isLayerVisible = (layer: Layer): boolean => layerVisibility()[layer];
+
+export {
+  currentTool,
+  setCurrentTool,
+  currentColor,
+  setCurrentColor,
+  activeLayer,
+  setActiveLayer,
+  layerVisibility,
+  setLayerVisibility,
+  toggleLayerVisibility,
+  isLayerVisible,
+  isDrawing,
+  setIsDrawing,
+  drawStart,
+  setDrawStart,
+  drawPreview,
+  setDrawPreview,
+  showShapeTools,
+  setShowShapeTools,
+};

--- a/src/stores/pixelStore.ts
+++ b/src/stores/pixelStore.ts
@@ -1,0 +1,220 @@
+import { createSignal, createMemo } from 'solid-js';
+import { Layer } from './drawingState';
+import { BlockColor } from '../data/minecraftColors';
+
+export interface Pixel {
+  x: number;
+  y: number;
+  color: string;
+  blockId: string;
+  blockName: string;
+  layer: Layer;
+}
+
+// Key generator for pixel map
+const pixelKey = (x: number, y: number): string => `${x},${y}`;
+
+// Main pixel storage
+const [pixels, setPixels] = createSignal<Map<string, Pixel>>(new Map());
+
+// Add or update a pixel
+const setPixel = (x: number, y: number, color: BlockColor, layer: Layer): void => {
+  const newPixels = new Map(pixels());
+  newPixels.set(pixelKey(x, y), {
+    x,
+    y,
+    color: color.color,
+    blockId: color.id,
+    blockName: color.name,
+    layer,
+  });
+  setPixels(newPixels);
+};
+
+// Set multiple pixels at once (for line/rectangle tools)
+const setMultiplePixels = (
+  coords: { x: number; y: number }[],
+  color: BlockColor,
+  layer: Layer
+): void => {
+  const newPixels = new Map(pixels());
+  for (const coord of coords) {
+    newPixels.set(pixelKey(coord.x, coord.y), {
+      x: coord.x,
+      y: coord.y,
+      color: color.color,
+      blockId: color.id,
+      blockName: color.name,
+      layer,
+    });
+  }
+  setPixels(newPixels);
+};
+
+// Remove a pixel
+const removePixel = (x: number, y: number): void => {
+  const newPixels = new Map(pixels());
+  newPixels.delete(pixelKey(x, y));
+  setPixels(newPixels);
+};
+
+// Remove multiple pixels
+const removeMultiplePixels = (coords: { x: number; y: number }[]): void => {
+  const newPixels = new Map(pixels());
+  for (const coord of coords) {
+    newPixels.delete(pixelKey(coord.x, coord.y));
+  }
+  setPixels(newPixels);
+};
+
+// Get a pixel at coordinates
+const getPixel = (x: number, y: number): Pixel | undefined => {
+  return pixels().get(pixelKey(x, y));
+};
+
+// Check if pixel exists
+const hasPixel = (x: number, y: number): boolean => {
+  return pixels().has(pixelKey(x, y));
+};
+
+// Get all pixels as array
+const getAllPixels = (): Pixel[] => Array.from(pixels().values());
+
+// Get pixels by layer
+const getPixelsByLayer = (layer: Layer): Pixel[] => {
+  return getAllPixels().filter((p) => p.layer === layer);
+};
+
+// Clear all pixels
+const clearAllPixels = (): void => {
+  setPixels(new Map());
+};
+
+// Clear pixels in a specific layer
+const clearLayer = (layer: Layer): void => {
+  const newPixels = new Map(pixels());
+  for (const [key, pixel] of newPixels) {
+    if (pixel.layer === layer) {
+      newPixels.delete(key);
+    }
+  }
+  setPixels(newPixels);
+};
+
+// Get unique colors used in the map
+const getUsedColors = createMemo(() => {
+  const colorMap = new Map<string, { color: string; blockId: string; blockName: string; count: number }>();
+  for (const pixel of pixels().values()) {
+    const existing = colorMap.get(pixel.blockId);
+    if (existing) {
+      existing.count++;
+    } else {
+      colorMap.set(pixel.blockId, {
+        color: pixel.color,
+        blockId: pixel.blockId,
+        blockName: pixel.blockName,
+        count: 1,
+      });
+    }
+  }
+  return Array.from(colorMap.values()).sort((a, b) => b.count - a.count);
+});
+
+// Flood fill algorithm
+const floodFill = (
+  startX: number,
+  startY: number,
+  newColor: BlockColor,
+  layer: Layer,
+  maxIterations: number = 10000
+): void => {
+  const targetPixel = getPixel(startX, startY);
+  const targetColor = targetPixel?.color ?? null;
+
+  // Don't fill if clicking on same color
+  if (targetColor === newColor.color) return;
+
+  const visited = new Set<string>();
+  const queue: { x: number; y: number }[] = [{ x: startX, y: startY }];
+  const toFill: { x: number; y: number }[] = [];
+
+  let iterations = 0;
+
+  while (queue.length > 0 && iterations < maxIterations) {
+    const { x, y } = queue.shift()!;
+    const key = pixelKey(x, y);
+
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    const pixel = getPixel(x, y);
+    const pixelColor = pixel?.color ?? null;
+
+    // Check if this pixel matches the target color
+    if (pixelColor === targetColor) {
+      toFill.push({ x, y });
+      // Add neighbors
+      queue.push({ x: x + 1, y }, { x: x - 1, y }, { x, y: y + 1 }, { x, y: y - 1 });
+    }
+
+    iterations++;
+  }
+
+  // Apply all fills at once
+  if (toFill.length > 0) {
+    setMultiplePixels(toFill, newColor, layer);
+  }
+};
+
+// Export/Import functionality
+interface ProjectData {
+  version: number;
+  pixels: Pixel[];
+  timestamp: string;
+}
+
+const exportProject = (): string => {
+  const data: ProjectData = {
+    version: 1,
+    pixels: getAllPixels(),
+    timestamp: new Date().toISOString(),
+  };
+  return JSON.stringify(data, null, 2);
+};
+
+const importProject = (jsonString: string): boolean => {
+  try {
+    const data: ProjectData = JSON.parse(jsonString);
+    if (data.version !== 1) {
+      console.error('Unsupported project version');
+      return false;
+    }
+    const newPixels = new Map<string, Pixel>();
+    for (const pixel of data.pixels) {
+      newPixels.set(pixelKey(pixel.x, pixel.y), pixel);
+    }
+    setPixels(newPixels);
+    return true;
+  } catch (e) {
+    console.error('Failed to import project:', e);
+    return false;
+  }
+};
+
+export {
+  pixels,
+  setPixel,
+  setMultiplePixels,
+  removePixel,
+  removeMultiplePixels,
+  getPixel,
+  hasPixel,
+  getAllPixels,
+  getPixelsByLayer,
+  clearAllPixels,
+  clearLayer,
+  getUsedColors,
+  floodFill,
+  exportProject,
+  importProject,
+};

--- a/src/tools/drawingHandlers.ts
+++ b/src/tools/drawingHandlers.ts
@@ -1,0 +1,172 @@
+// Drawing tool handlers for the pixel map generator
+
+import {
+  currentTool,
+  currentColor,
+  activeLayer,
+  isDrawing,
+  setIsDrawing,
+  drawStart,
+  setDrawStart,
+  setDrawPreview,
+} from '../stores/drawingState';
+
+import {
+  setPixel,
+  setMultiplePixels,
+  removePixel,
+  floodFill,
+} from '../stores/pixelStore';
+
+// Bresenham line algorithm to get all points between two coordinates
+export const getLinePoints = (
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+): { x: number; y: number }[] => {
+  const points: { x: number; y: number }[] = [];
+  const dx = Math.abs(x1 - x0);
+  const dy = Math.abs(y1 - y0);
+  const sx = x0 < x1 ? 1 : -1;
+  const sy = y0 < y1 ? 1 : -1;
+  let err = dx - dy;
+
+  let x = x0;
+  let y = y0;
+
+  while (true) {
+    points.push({ x, y });
+
+    if (x === x1 && y === y1) break;
+
+    const e2 = 2 * err;
+    if (e2 > -dy) {
+      err -= dy;
+      x += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y += sy;
+    }
+  }
+
+  return points;
+};
+
+// Get all points in a rectangle
+export const getRectanglePoints = (
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+): { x: number; y: number }[] => {
+  const points: { x: number; y: number }[] = [];
+  const minX = Math.min(x0, x1);
+  const maxX = Math.max(x0, x1);
+  const minY = Math.min(y0, y1);
+  const maxY = Math.max(y0, y1);
+
+  for (let x = minX; x <= maxX; x++) {
+    for (let y = minY; y <= maxY; y++) {
+      points.push({ x, y });
+    }
+  }
+
+  return points;
+};
+
+// Handle drawing start (mouse down)
+export const handleDrawStart = (cellX: number, cellY: number): void => {
+  const tool = currentTool();
+
+  if (tool === 'select') {
+    // Pan mode - don't handle drawing
+    return;
+  }
+
+  if (tool === 'pencil') {
+    setPixel(cellX, cellY, currentColor(), activeLayer());
+  } else if (tool === 'eraser') {
+    removePixel(cellX, cellY);
+  } else if (tool === 'fill') {
+    floodFill(cellX, cellY, currentColor(), activeLayer());
+  } else if (tool === 'line' || tool === 'rectangle') {
+    setIsDrawing(true);
+    setDrawStart({ x: cellX, y: cellY });
+    setDrawPreview([{ x: cellX, y: cellY }]);
+  }
+};
+
+// Handle drawing move (mouse move while drawing)
+export const handleDrawMove = (cellX: number, cellY: number): void => {
+  const tool = currentTool();
+
+  if (tool === 'select') {
+    return;
+  }
+
+  if (!isDrawing()) {
+    // Not in a drag operation
+    if (tool === 'pencil') {
+      setPixel(cellX, cellY, currentColor(), activeLayer());
+    } else if (tool === 'eraser') {
+      removePixel(cellX, cellY);
+    }
+    return;
+  }
+
+  // In drag operation for line/rectangle
+  const start = drawStart();
+  if (!start) return;
+
+  if (tool === 'line') {
+    const points = getLinePoints(start.x, start.y, cellX, cellY);
+    setDrawPreview(points);
+  } else if (tool === 'rectangle') {
+    const points = getRectanglePoints(start.x, start.y, cellX, cellY);
+    setDrawPreview(points);
+  }
+};
+
+// Handle drawing end (mouse up)
+export const handleDrawEnd = (cellX: number, cellY: number): void => {
+  const tool = currentTool();
+
+  if (tool === 'select') {
+    return;
+  }
+
+  if (!isDrawing()) return;
+
+  const start = drawStart();
+  if (!start) {
+    setIsDrawing(false);
+    setDrawPreview([]);
+    return;
+  }
+
+  if (tool === 'line') {
+    const points = getLinePoints(start.x, start.y, cellX, cellY);
+    setMultiplePixels(points, currentColor(), activeLayer());
+  } else if (tool === 'rectangle') {
+    const points = getRectanglePoints(start.x, start.y, cellX, cellY);
+    setMultiplePixels(points, currentColor(), activeLayer());
+  }
+
+  setIsDrawing(false);
+  setDrawStart(null);
+  setDrawPreview([]);
+};
+
+// Handle drawing cancel (mouse leave while drawing)
+export const handleDrawCancel = (): void => {
+  setIsDrawing(false);
+  setDrawStart(null);
+  setDrawPreview([]);
+};
+
+// Check if we should be in drawing mode (not panning)
+export const isDrawingMode = (): boolean => {
+  return currentTool() !== 'select';
+};


### PR DESCRIPTION
Add drawing tools (pencil, eraser, line, rectangle, fill) for creating pixel-based building layouts. Implement Minecraft-themed block color palette organized by categories. Add layer system for organizing terrain, structures, paths, and markers. Include project save/load functionality and legend showing used colors.

Features:
- 6 drawing tools: pan, pencil, eraser, line, rectangle, flood fill
- Color palette with 50+ Minecraft block colors
- 4-layer system with visibility toggles
- Save/load projects as JSON
- Real-time legend showing used blocks and counts
- Shape generator preserved as optional stamp tool